### PR TITLE
Prepare new snapshot version

### DIFF
--- a/mscred.par
+++ b/mscred.par
@@ -12,4 +12,4 @@ ssfile,s,h,"subsets",,,Subset translation file
 im_bufsize,r,h,0.065536,0.001024,,Image I/O buffer size (in Mbytes)
 graphics,s,h,"stdgraph",,,Interactive graphics output device
 cursor,*gcur,h,"",,,Graphics cursor input
-version,s,h,"V5.05: August 9, 2012"
+version,s,h,"V5.05: 2018.07.09"


### PR DESCRIPTION
To make version comparison simpler, we also switch from the `August 9, 2012` format to the `2018.07.06` format. This allows an automated test which version is higher.