### PR TITLE
Use mkfloat.sh in mkpkg

### DIFF
--- a/README
+++ b/README
@@ -101,7 +101,7 @@ loginuser.cl file, or interactively as follows.
 To define the package you need to an IRAF logical  path  to  the  mscred
 directory  and a "task" declaration.  As noted above, this is often done
 in the $iraf/unix/hlib/extern.pkg file but it can also be done  in  your
-irafuser.csh  file  or  even interactively.  The statements you need are
+irafuser.sh  file  or  even interactively.  The statements  you need are
 something like:
 
     reset mscred = /local/mscred/
@@ -144,12 +144,12 @@ COMPILING
 
 If  you will be compiling the package, as opposed to installing a binary
 distribution, then you need to  define  various  environment  variables.
-The following is for Unix/csh which is the main supported environment.
+The following is for Unix which is the main supported environment.
 
-    % setenv iraf /iraf/iraf/             # Path to IRAF root (example)
-    % source $iraf/unix/hlib/irafuser.csh # Define rest of environment
-    % setenv IRAFARCH redhat              # IRAF architecture
-    % setenv mscred <path>/               # Path to package
+    % export iraf=/iraf/iraf/             # Path to IRAF root (example)
+    % source $iraf/unix/hlib/irafuser.sh  # Define rest of environment
+    % export IRAFARCH=linux64             # IRAF architecture
+    % export mscred=<path>/               # Path to package
 
 where  you  need to supply the appropriate path to the IRAF installation
 root in the first step and the IRAF  architecture  identifier  for  your

--- a/doc/installation.hlp
+++ b/doc/installation.hlp
@@ -111,7 +111,7 @@ your loginuser.cl file, or interactively as follows.
 To define the package you need to an IRAF logical path to the mscred
 directory and a "task" declaration.  As noted above, this is often
 done in the $iraf/unix/hlib/extern.pkg file but it can also be done
-in your irafuser.csh file or even interactively.  The statements you
+in your irafuser.sh file or even interactively.  The statements you
 need are something like:
 
 .nf
@@ -159,13 +159,13 @@ COMPILING
 
 If you will be compiling the package, as opposed to installing a binary
 distribution, then you need to define various environment variables.
-The following is for Unix/csh which is the main supported environment.
+The following is for Unix which is the main supported environment.
 
 .nf
-    % setenv iraf /iraf/iraf/             # Path to IRAF root (example)
-    % source $iraf/unix/hlib/irafuser.csh # Define rest of environment
-    % setenv IRAFARCH redhat              # IRAF architecture
-    % setenv mscred <path>/		  # Path to package
+    % export iraf=/iraf/iraf/            # Path to IRAF root (example)
+    % source $iraf/unix/hlib/irafuser.sh # Define rest of environment
+    % export IRAFARCH=redhat             # IRAF architecture
+    % export mscred=<path>/		 # Path to package
 .fi
 
 where you need to supply the appropriate path to the IRAF installation root

--- a/mkpkg
+++ b/mkpkg
@@ -43,7 +43,7 @@ summary:
 arch:					# show current float option
 showfloat:
 	$verbose off
-	!$(hlib)/mkfloat.csh
+	!$(hlib)/mkfloat
 	;
 generic:				# generic installation (no bin)
 	$ifnfile (bin.generic)
@@ -51,7 +51,7 @@ generic:				# generic installation (no bin)
 	$endif
 	$verbose off
 	$set DIRS = "lib src"
-	!$(hlib)/mkfloat.csh generic -d $(DIRS)
+	!$(hlib)/mkfloat generic -d $(DIRS)
 	;
 
 freebsd:				# install FreeBSD binaries
@@ -60,7 +60,7 @@ freebsd:				# install FreeBSD binaries
 	$endif
 	$verbose off
 	$set DIRS = "lib src"
-	!$(hlib)/mkfloat.csh freebsd -d $(DIRS)
+	!$(hlib)/mkfloat freebsd -d $(DIRS)
 	;
 linux:					# install Linux 32-bit binaries
 	$ifnfile (bin.linux)
@@ -68,7 +68,7 @@ linux:					# install Linux 32-bit binaries
 	$endif
 	$verbose off
 	$set DIRS = "lib src"
-	!$(hlib)/mkfloat.csh linux -d $(DIRS)
+	!$(hlib)/mkfloat linux -d $(DIRS)
 	;
 linux64:				# install Linux 64-bit binaries
 	$ifnfile (bin.linux64)
@@ -76,7 +76,7 @@ linux64:				# install Linux 64-bit binaries
 	$endif
 	$verbose off
 	$set DIRS = "lib src"
-	!$(hlib)/mkfloat.csh linux64 -d $(DIRS)
+	!$(hlib)/mkfloat linux64 -d $(DIRS)
 	;
 macosx:					# install Mac OS X (PPC) binaries
 	$ifnfile (bin.macosx)
@@ -84,7 +84,7 @@ macosx:					# install Mac OS X (PPC) binaries
 	$endif
 	$verbose off
 	$set DIRS = "lib src"
-	!$(hlib)/mkfloat.csh macosx -d $(DIRS)
+	!$(hlib)/mkfloat macosx -d $(DIRS)
 	;
 macintel:				# install Mac OS X (Intel) binaries
 	$ifnfile (bin.macintel)
@@ -92,7 +92,7 @@ macintel:				# install Mac OS X (Intel) binaries
 	$endif
 	$verbose off
 	$set DIRS = "lib src"
-	!$(hlib)/mkfloat.csh macintel -d $(DIRS)
+	!$(hlib)/mkfloat macintel -d $(DIRS)
 	;
 cygwin:					# install Cygwin binaries
 	$ifnfile (bin.macintel)
@@ -100,7 +100,7 @@ cygwin:					# install Cygwin binaries
 	$endif
 	$verbose off
 	$set DIRS = "lib src"
-	!$(hlib)/mkfloat.csh macintel -d $(DIRS)
+	!$(hlib)/mkfloat macintel -d $(DIRS)
 	;
 redhat:					# install Redhat Linux binaries
 	$ifnfile (bin.redhat)
@@ -108,7 +108,7 @@ redhat:					# install Redhat Linux binaries
 	$endif
 	$verbose off
 	$set DIRS = "lib src"
-	!$(hlib)/mkfloat.csh redhat -d $(DIRS)
+	!$(hlib)/mkfloat redhat -d $(DIRS)
 	;
 sparc:					# install sparc binaries
 	$ifnfile (bin.sparc)
@@ -116,7 +116,7 @@ sparc:					# install sparc binaries
 	$endif
 	$verbose off
 	$set DIRS = "lib src"
-	!$(hlib)/mkfloat.csh sparc -d $(DIRS)
+	!$(hlib)/mkfloat sparc -d $(DIRS)
 	;
 ssun:					# install Sun/Solaris binaries
 	$ifnfile (bin.ssun)
@@ -124,7 +124,7 @@ ssun:					# install Sun/Solaris binaries
 	$endif
 	$verbose off
 	$set DIRS = "lib src"
-	!$(hlib)/mkfloat.csh ssun -d $(DIRS)
+	!$(hlib)/mkfloat ssun -d $(DIRS)
 	;
 sunos:					# install SunOS (Solaris x86) binaries
 	$ifnfile (bin.sunos)
@@ -132,7 +132,7 @@ sunos:					# install SunOS (Solaris x86) binaries
 	$endif
 	$verbose off
 	$set DIRS = "lib src"
-	!$(hlib)/mkfloat.csh sunos -d $(DIRS)
+	!$(hlib)/mkfloat sunos -d $(DIRS)
 	;
 noP2R:
 	!find . -type f -name '*[xh]' -exec grep -q P2R {} \; -exec sed -i -e 's+P2R++g' {} \;


### PR DESCRIPTION
IRAF now uses `/bin/sh` compatible scripts instead of (t)csh. Since the shell name is encoded in the suffix, this needs to be changed in mkpkg.
