### PR TITLE
Force usage of images/tv package in mscdisplay build

### DIFF
--- a/src/mscdisplay/mkpkg
+++ b/src/mscdisplay/mkpkg
@@ -20,14 +20,8 @@ mscdisplay:
 
 	$checkout x_mscdisplay.o mscbin$
 	$omake	x_mscdisplay.x
-	$iffile (pkg$images/tv/display/imdwcsver.x)
-	    $link x_mscdisplay.o -lsf -lmscdisp\
-		$(LIBS1) $(LIBS2) -o xx_mscdisplay.e
-	$else
-	    $omake imdwcsver.x
-	    $link x_mscdisplay.o imdwcsver.o -lsf -lmscdisp\
-		$(LIBS1) $(LIBS2) -o xx_mscdisplay.e
-	$endif
+	$link x_mscdisplay.o -lsf -lmscdisp\
+	    $(LIBS1) $(LIBS2) -o xx_mscdisplay.e
 	$checkin x_mscdisplay.o mscbin$
 	;
 
@@ -37,14 +31,8 @@ mscexam:
 
 	$checkout x_mscexam.o mscbin$
 	$omake	x_mscexam.x
-	$iffile (pkg$images/tv/display/imdwcsver.x)
-	    $link x_mscexam.o -limexam -lmscdisp\
-		$(LIBS1) $(LIBS2) -o xx_mscexam.e
-	$else
-	    $omake imdwcsver.x
-	    $link x_mscexam.o imdwcsver.o -limexam -lmscdisp\
-		$(LIBS1) $(LIBS2) -o xx_mscexam.e
-	$endif
+	$link x_mscexam.o -limexam -lmscdisp\
+	    $(LIBS1) $(LIBS2) -o xx_mscexam.e
 	$checkin x_mscexam.o mscbin$
 	;
 


### PR DESCRIPTION
The file pkg/images/tv/display/imdwcsver.x was introduced in IRAF 2.12, so we don't need to longer check the it is there.

Otherwise, the build will fail with a stripped version of IRAF.