### PR TITLE
Use nttools instead of STSDAS' tables.ttools package

### DIFF
--- a/src/mscfinder/mktpeaktab.cl
+++ b/src/mscfinder/mktpeaktab.cl
@@ -19,8 +19,7 @@ begin
 	    error (1, "No input list of coordinates to make TPEAK table")
 
 	# Load table tools.
-	tables
-	ttools
+	nttools
 
 	temp1 = mktemp ("tmp$iraf")
 	temp2 = mktemp ("tmp$iraf")

--- a/src/mscfinder/mscfinder.cl
+++ b/src/mscfinder/mscfinder.cl
@@ -1,8 +1,6 @@
 #{ MSCFINDER.CL -- Script to set up tasks in the MSCFINDER package
 
 proto
-tables
-ttools
 immatch
 
 package	mscfinder


### PR DESCRIPTION
This cherry-picked https://github.com/noirlab-iraf/mscred/commit/7ce7a0efb9e9eb1a2a4bd0c483943f52a4a03106 and https://github.com/noirlab-iraf/mscred/commit/13e9b498315a287b157a58397a30d5ec2fa6464a which remove the dependency from STSDAS.

Fixes: #7 