### PR TITLE
NOIRLAB: Fix use of 'errstr' pointer

### DIFF
--- a/src/ccdred/src/combine/src/icgscale.x
+++ b/src/ccdred/src/combine/src/icgscale.x
@@ -57,11 +57,11 @@ begin
 		call close (fd)
 		if (i < nimages) {
 		    call salloc (errstr, SZ_LINE, TY_CHAR)
-		    call sprintf (errstr, SZ_FNAME,
+		    call sprintf (Memc[errstr], SZ_FNAME,
 			"Insufficient %s values in %s")
 			call pargstr (param)
 			call pargstr (name[2])
-		    call error (1, errstr)
+		    call error (1, Memc[errstr])
 		}
 	    }
 	} else if (name[1] == '!') {

--- a/src/mscfinder/t_tfield.x
+++ b/src/mscfinder/t_tfield.x
@@ -177,7 +177,7 @@ real	xref, yref, xref1, yref1
 real	plt_epoch, plt_epoch1, width, edge, pos_angle
 double	obs_epoch, ut, dra, ddec
 long	xsize, ysize
-int	north, east, day, month, year, token1, token2
+int	north, east, day, month, year
 char	tokstr[SZ_TOKEN]
 
 real	clgetr(), imgetr()
@@ -185,9 +185,6 @@ double	imgetd()
 int	clgwrd(), strmatch(), btoi(), nscan()
 bool	clgetb()
 pointer	immap()
-
-data	token1	/NULL/
-data	token2	/NULL/
 
 begin
 	call smark (sp)

--- a/src/xtalk.x
+++ b/src/xtalk.x
@@ -30,8 +30,6 @@ real	val
 
 pointer	imgl2s(), impl2s(), imgs2s(), imps2s(), sthead(), stnext()
 
-pointer	stname()
-
 begin
 	# Loop through each line and correct all dependent output images
 	# at the same line.
@@ -666,8 +664,6 @@ pointer	sym, inbuf, outbuf, outbufs[2]
 real	val
 
 pointer	imgl2r(), impl2r(), imgs2r(), imps2r(), sthead(), stnext()
-
-pointer	stname()
 
 begin
 	# Loop through each line and correct all dependent output images


### PR DESCRIPTION
Cherry-picked 69365d5be49f70a148ec558422dd6fb375d670aa from NOIRLab's repository. Also some cleanup from 46769b9788362a01cca467a843eb44befb04cb5e and c9a68d7c4f2ab89b8d71b531b93beef265ea65f7. 

Author @mjfitzpatrick