### PR TITLE
NOIRLAB: added missing token defs

### DIFF
--- a/src/mscfinder/t_tfield.x
+++ b/src/mscfinder/t_tfield.x
@@ -179,6 +179,10 @@ double	obs_epoch, ut, dra, ddec
 long	xsize, ysize
 int	north, east, day, month, year
 char	tokstr[SZ_TOKEN]
+int     token1, token2
+
+data    token1  /NULL/
+data    token2  /NULL/
 
 real	clgetr(), imgetr()
 double	imgetd()


### PR DESCRIPTION
Taken from NOIRLABs branch, f176f2c5224e3d99dbef6ce9e6dbfcc163e129a3, author @mjfitzpatrick